### PR TITLE
Atmel flash fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ mgba_log = "0.2.1"
 more_ranges = "0.1.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(sram)", "cfg(flash_64k)", "cfg(flash_128k)"]}
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(sram)", "cfg(flash_64k)", "cfg(flash_64k_atmel)", "cfg(flash_128k)"]}


### PR DESCRIPTION
Adds tests for atmel flash writes, and also fixes some incorrect logic.

Note for the future: mgba doesn't support emulating an Atmel flash chip. However, no$gba does, Therefore, this was actually  tested against no$gba. To use logging, I used the `nocash_gba_log` crate.